### PR TITLE
compatibility with Coq 8.11 to 8.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 *.glob
 *.vo
 *.v.d
-/.coqdeps.d
-/Makefile.coq
-/Makefile.coq.conf
-/html
+*.vos
+*.vok
+*.aux
+.coqdeps.d
+.Makefile.coq.d
+.coq-native
+Makefile.coq
+Makefile.coq.conf
+html

--- a/Cut.v
+++ b/Cut.v
@@ -114,6 +114,7 @@ Definition Rneq (x y : R) := (Rlt x y \/ Rlt y x)%type.
 
 (** We introduce notation for equality, order and apartness. We put the notation
     in the scope [R_scope] which can then be opened whenever needed. *)
+Declare Scope R_scope.
 Infix "<=" := Rle : R_scope.
 Infix "<" := Rlt : R_scope.
 Infix "==" := Req : R_scope.

--- a/Makefile
+++ b/Makefile
@@ -1,63 +1,16 @@
-# Based on example given by Adam Chlipala, in “Theorem Proving in the Large”,
-# section “Build Patterns”. http://adam.chlipala.net/cpdt/html/Large.html
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
 
-# Usage examples:
-#     make
-#     make all
-#     make html
-#     make clean
+clean: Makefile.coq
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
 
-# Modules to be included in the main build:
-MODULES := \
-	MiscLemmas \
-	Cut \
-	Additive \
-	Multiplication \
-	MinMax \
-	Archimedean \
-	Completeness \
-	Order \
-	Cauchy \
-	DecOrder
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
-VS      := $(MODULES:%=%.v)
+force _CoqProject Makefile: ;
 
-# The HoTT coq binaries (“hoqc” etc.) are used by default.  These can
-# be overridden by explicitly passing a different value of COQC, e.g.
-#     make COQC=coqc
-# COQDEP and COQDOC are set automatically based on COQC, but we are not
-# very clever about this, so if it doesn’t work, these can be explicitly
-# specified too.
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
 
-COQC ?= coqc
-COQDEP ?= coqdep
-COQDOC ?= coqdoc
-
-export COQC COQDEP COQDOC
-
-# You may specify th elocation of your Coq binaries by setting the environment
-# variables COQBIN
-
-COQMAKEFILE = $(COQBIN)coq_makefile
-
-.PHONY: coq all install clean html
-
-coq: Makefile.coq
-	$(MAKE) -f Makefile.coq
-
-Makefile.coq: Makefile $(VS)
-	$(COQMAKEFILE) -Q . "''" COQC = "$(COQC)" COQDEP = "$(COQDEP)" $(VS) -o Makefile.coq
-
-install: Makefile.coq
-	$(MAKE) -f Makefile.coq install
-
-clean:: Makefile.coq
-	$(MAKE) -f Makefile.coq clean
-	rm -f Makefile*.coq
-	rm -f html
-
-cleaner:
-	rm -f **/*.glob **/*.vo **/*.v.d **/*~ **/.*.aux
-
-html:: Makefile.coq
-	$(MAKE) -f Makefile.coq html
+.PHONY: all clean force

--- a/MiscLemmas.v
+++ b/MiscLemmas.v
@@ -1,9 +1,9 @@
 (** Various lemmas that seem to be missing from the standard library. *)
 
-Require Import QArith Qminmax Qabs.
+Require Import QArith Qminmax Qabs Lia.
 
 Definition compose {A B C} (g : B -> C) (f : A -> B) := fun x => g (f x).
-Hint Unfold compose.
+Hint Unfold compose : core.
 Notation "g 'o' f" := (compose g f) (at level 40, left associativity).
 
 Definition const A B (y : B) : A -> B := (fun x => y).
@@ -31,7 +31,7 @@ Lemma Qopp_lt_compat : forall (p q : Q), p < q <-> -q < -p.
 Proof.
   intros [a b] [c d].
   unfold Qlt. simpl.
-  rewrite !Z.mul_opp_l. omega.
+  rewrite !Z.mul_opp_l. lia.
 Defined.
 
 Lemma Qplus_lt_lt_compat : forall (p q r s : Q), p < q -> r < s -> p + r < q + s.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The formalization started as a student project at the University of Ljubljana.
 At this point the formalization of the field of reals is finished.
 
 There are still several unfinished theorems concering the lattice-theoretic structure of the reals (search for `todo` in the Coq files). We would be delighted by contributions that would bring the formalization
-closer to completeion.
+closer to completion.
 
 #### Compilation instruction
 
@@ -14,7 +14,7 @@ A fairly recent version of Coq should do. Run `make` to compile the files:
 * `make all` -- to make all that is to be made
 * `make clean` -- to remove the compiled files
 * `make html` -- to make the HTML documentation
-* `make install` -- we have never tried to run this
+* `make install` -- installs files as the library `DedekindReals`
 
 #### Structure of the modules
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,0 +1,14 @@
+-R . DedekindReals
+
+-arg -w -arg -deprecated-instance-without-locality
+
+Additive.v
+Archimedean.v
+Cauchy.v
+Completeness.v
+Cut.v
+DecOrder.v
+MinMax.v
+MiscLemmas.v
+Multiplication.v
+Order.v


### PR DESCRIPTION
This library is currently referenced in the Coq documentation for the reals, so I think it would be nice if it compiled with recent Coq versions. However, it looks like it currently can't be built with *any* Coq version, which I address in this PR. I also replace build boilerplate with the standard one we use in [coq-community](https://github.com/coq-community/). Finally, I make the library *installable*, so that one could theoretically use it as an instance of Coq reals in a third-party project.

To improve possibilities for maintenance as Coq evolves, and achieve greater visibility to attract contributors, maybe you would consider maintaining this project [as part of coq-community](https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md#proposing-a-new-package)? 